### PR TITLE
fix: update route

### DIFF
--- a/src/components/AccountAddress.tsx
+++ b/src/components/AccountAddress.tsx
@@ -51,7 +51,7 @@ export const AccountAddress = (props: AccountLinkProps) => {
 
 		if (link) {
 			content = (
-				<Link to={`/${network}/account/${address}`}>
+				<Link to={`/account/${address}`}>
 					{content}
 				</Link>
 			);

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -129,7 +129,7 @@ function SearchInput(props: SearchInputProps) {
 
 			e.preventDefault();
 			localStorage.setItem("network", network);
-			navigate(`/${network}/search?query=${search}`);
+			navigate(`/search?query=${search}`);
 		},
 		[navigate, network, search]
 	);

--- a/src/components/balances/BalancesTable.tsx
+++ b/src/components/balances/BalancesTable.tsx
@@ -88,7 +88,7 @@ function BalancesTable(props: BalancesTableProps) {
 			<BalancesItemsTableAttribute
 				label="Last update"
 				render={(balance) =>
-					<Link to={`/${network}/search?query=${balance.updatedAt}`}>
+					<Link to={`/search?query=${balance.updatedAt}`}>
 						{balance.updatedAt}
 					</Link>
 				}

--- a/src/components/blocks/BlockInfoTable.tsx
+++ b/src/components/blocks/BlockInfoTable.tsx
@@ -51,7 +51,7 @@ export const BlockInfoTable = (props: BlockInfoTableProps) => {
 			<BlockInfoTableAttribute
 				label="Parent hash"
 				render={(data) =>
-					<Link to={`/${network}/search?query=${data.parentHash}`}>
+					<Link to={`/search?query=${data.parentHash}`}>
 						{data.parentHash}
 					</Link>
 				}

--- a/src/components/blocks/BlocksTable.tsx
+++ b/src/components/blocks/BlocksTable.tsx
@@ -36,7 +36,7 @@ function ExtrinsicsTable(props: BlocksTableProps) {
 			<BlocksTableAttribute
 				label="Height"
 				render={(block) =>
-					<Link to={`/${network}/block/${block.id}`}>
+					<Link to={`/block/${block.id}`}>
 						{block.height}
 					</Link>
 				}

--- a/src/components/calls/CallInfoTable.tsx
+++ b/src/components/calls/CallInfoTable.tsx
@@ -49,7 +49,7 @@ export const CallInfoTable = (props: CallInfoTableProps) => {
 			<CallInfoTableAttribute
 				label="Block"
 				render={(data) =>
-					<Link to={`/${network}/block/${data.blockId}`}>
+					<Link to={`/block/${data.blockId}`}>
 						{data.blockHeight}
 					</Link>
 				}
@@ -58,7 +58,7 @@ export const CallInfoTable = (props: CallInfoTableProps) => {
 			<CallInfoTableAttribute
 				label="Extrinsic"
 				render={(data) =>
-					<Link to={`/${network}/extrinsic/${data.extrinsicId}`}>
+					<Link to={`/extrinsic/${data.extrinsicId}`}>
 						{data.extrinsicId}
 					</Link>
 				}
@@ -67,7 +67,7 @@ export const CallInfoTable = (props: CallInfoTableProps) => {
 			<CallInfoTableAttribute
 				label="Parent call"
 				render={(data) => data.parentId &&
-					<Link to={`/${network}/call/${data.parentId}`}>
+					<Link to={`/call/${data.parentId}`}>
 						{data.parentId}
 					</Link>
 				}
@@ -102,7 +102,7 @@ export const CallInfoTable = (props: CallInfoTableProps) => {
 				label="Name"
 				render={(data) =>
 					<ButtonLink
-						to={`/${network}/search?query=${data.palletName}.${data.callName}`}
+						to={`/search?query=${data.palletName}.${data.callName}`}
 						size="small"
 						color="secondary"
 					>

--- a/src/components/calls/CallsTable.tsx
+++ b/src/components/calls/CallsTable.tsx
@@ -29,7 +29,7 @@ export const CallsTable = (props: CallsTableProps) => {
 			<CallsTableAttribute
 				label="ID"
 				render={(call) =>
-					<Link to={`/${network}/call/${call.id}`}>
+					<Link to={`/call/${call.id}`}>
 						{call.id}
 					</Link>
 				}
@@ -38,7 +38,7 @@ export const CallsTable = (props: CallsTableProps) => {
 				label="Name"
 				render={(call) =>
 					<ButtonLink
-						to={`/${network}/search?query=${call.palletName}.${call.callName}`}
+						to={`/search?query=${call.palletName}.${call.callName}`}
 						size="small"
 						color="secondary"
 					>
@@ -63,7 +63,7 @@ export const CallsTable = (props: CallsTableProps) => {
 			<CallsTableAttribute
 				label="Extrinsic"
 				render={(call) =>
-					<Link to={`/${network}/extrinsic/${call.extrinsicId}`}>
+					<Link to={`/extrinsic/${call.extrinsicId}`}>
 						{call.extrinsicId}
 					</Link>
 				}

--- a/src/components/events/EventInfoTable.tsx
+++ b/src/components/events/EventInfoTable.tsx
@@ -42,7 +42,7 @@ export const EventInfoTable = (props: EventInfoTableProps) => {
 				label="Block"
 				render={(data) =>
 					<Link
-						to={`/${network}/block/${data.blockId}`}
+						to={`/block/${data.blockId}`}
 					>
 						{data.blockHeight}
 					</Link>
@@ -53,7 +53,7 @@ export const EventInfoTable = (props: EventInfoTableProps) => {
 				label="Extrinsic"
 				render={(data) => data.extrinsicId &&
 					<Link
-						to={`/${network}/extrinsic/${data.extrinsicId}`}
+						to={`/extrinsic/${data.extrinsicId}`}
 					>
 						{data.extrinsicId}
 					</Link>
@@ -64,7 +64,7 @@ export const EventInfoTable = (props: EventInfoTableProps) => {
 				label="Call"
 				render={(data) => data.callId &&
 					<Link
-						to={`/${network}/call/${data.callId}`}
+						to={`/call/${data.callId}`}
 					>
 						{data.callId}
 					</Link>
@@ -75,7 +75,7 @@ export const EventInfoTable = (props: EventInfoTableProps) => {
 				label="Name"
 				render={(data) =>
 					<ButtonLink
-						to={`/${network}/search?query=${data.palletName}.${data.eventName}`}
+						to={`/search?query=${data.palletName}.${data.eventName}`}
 						size="small"
 						color="secondary"
 					>

--- a/src/components/events/EventsTable.tsx
+++ b/src/components/events/EventsTable.tsx
@@ -39,7 +39,7 @@ function EventsTable(props: EventsTableProps) {
 			<EventsItemsTableAttribute
 				label="ID"
 				render={(event) => (
-					<Link to={`/${network}/event/${event.id}`}>
+					<Link to={`/event/${event.id}`}>
 						{event.id}
 					</Link>
 				)}
@@ -48,7 +48,7 @@ function EventsTable(props: EventsTableProps) {
 				label="Name"
 				render={(event) =>
 					<ButtonLink
-						to={`/${network}/search?query=${event.palletName}.${event.eventName}`}
+						to={`/search?query=${event.palletName}.${event.eventName}`}
 						size="small"
 						color="secondary"
 					>
@@ -60,7 +60,7 @@ function EventsTable(props: EventsTableProps) {
 				<EventsItemsTableAttribute
 					label="Extrinsic"
 					render={(event) => event.extrinsicId && (
-						<Link to={`/${network}/extrinsic/${event.extrinsicId}`}>
+						<Link to={`/extrinsic/${event.extrinsicId}`}>
 							{event.extrinsicId}
 						</Link>
 					)}

--- a/src/components/extrinsics/ExtrinsicInfoTable.tsx
+++ b/src/components/extrinsics/ExtrinsicInfoTable.tsx
@@ -54,7 +54,7 @@ export const ExtrinsicInfoTable = (props: ExtrinsicInfoTableProps) => {
 			<ExtrinsicInfoTableAttribute
 				label="Block"
 				render={(data) =>
-					<Link to={`/${network}/block/${data.blockId}`}>
+					<Link to={`/block/${data.blockId}`}>
 						{data.blockHeight}
 					</Link>
 				}
@@ -88,7 +88,7 @@ export const ExtrinsicInfoTable = (props: ExtrinsicInfoTableProps) => {
 				label="Name"
 				render={(data) =>
 					<ButtonLink
-						to={`/${network}/search?query=${data.palletName}.${data.callName}`}
+						to={`/search?query=${data.palletName}.${data.callName}`}
 						size="small"
 						color="secondary"
 					>

--- a/src/components/extrinsics/ExtrinsicsTable.tsx
+++ b/src/components/extrinsics/ExtrinsicsTable.tsx
@@ -37,7 +37,7 @@ function ExtrinsicsTable(props: ExtrinsicsTableProps) {
 			<ExtrinsicsTableAttribute
 				label="ID"
 				render={(extrinsic) =>
-					<Link to={`/${network}/extrinsic/${extrinsic.id}`}>
+					<Link to={`/extrinsic/${extrinsic.id}`}>
 						{extrinsic.id}
 					</Link>
 				}
@@ -46,7 +46,7 @@ function ExtrinsicsTable(props: ExtrinsicsTableProps) {
 				label="Name"
 				render={(extrinsic) =>
 					<ButtonLink
-						to={`/${network}/search?query=${extrinsic.palletName}.${extrinsic.callName}`}
+						to={`/search?query=${extrinsic.palletName}.${extrinsic.callName}`}
 						size="small"
 						color="secondary"
 					>

--- a/src/components/transfers/TransfersTable.tsx
+++ b/src/components/transfers/TransfersTable.tsx
@@ -43,7 +43,7 @@ function TransfersTable(props: TransfersTableProps) {
 			<TransfersTableAttribute
 				label="Extrinsic"
 				render={(transfer) => transfer.extrinsic &&
-					<Link to={`/${network}/extrinsic/${transfer.extrinsic.id}`}>
+					<Link to={`/extrinsic/${transfer.extrinsic.id}`}>
 						{transfer.extrinsic.id}
 					</Link>
 				}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,7 +7,6 @@ import { encodeAddress } from "./utils/formatAddress";
 import { AccountPage } from "./screens/account";
 import { BlockPage } from "./screens/block";
 import { CallPage } from "./screens/call";
-import { NetworkPage } from "./screens/network";
 import { EventPage } from "./screens/event";
 import { ExtrinsicPage } from "./screens/extrinsic";
 import { HomePage } from "./screens/home";
@@ -19,24 +18,27 @@ import { config } from "./config";
 
 export const router = createBrowserRouter([
 	{
+		id: "home",
 		path: "/",
+		loader: ({ params }) => {
+			// const { network: networkName } = params;
+			const network = getNetwork("polkadot", false);
+
+			return { network };
+		},
 		element: <HomePage />,
 	},
 	{
 		id: "root",
-		path: ":network",
+		path: "*",
 		loader: ({ params }) => {
-			const { network: networkName } = params;
-			const network = networkName ? getNetwork(networkName, false) : undefined;
+			// const { network: networkName } = params;
+			const network = getNetwork("polkadot", false);
 
 			return { network };
 		},
 		element: <ResultLayout />,
 		children: [
-			{
-				index: true,
-				element: <NetworkPage />,
-			},
 			{
 				path: "extrinsic/:id",
 				element: <ExtrinsicPage />,


### PR DESCRIPTION
Calamar app is built to support multiple networks, so all routes start with a network name.
e.g. /polkadot/extrinsics/:id

Remove the network name from all routes.